### PR TITLE
Buttons Folder, walkaway

### DIFF
--- a/src/components/Buttons/WalkAwayButton.jsx
+++ b/src/components/Buttons/WalkAwayButton.jsx
@@ -1,0 +1,16 @@
+import React from "react"
+
+function WalkAwayButton() {
+    const handleClick = () => {
+        // When the button is clicked display an console! 
+        console.log("Player has walked away from the deal!")
+    }
+
+    return (
+        <button onClick={handleClick}>
+            Walk away
+        </button>
+    )
+}
+
+export default WalkAwayButton


### PR DESCRIPTION
Created a walk away button,

Added a buttons folder for new buttons to be added to the app. 

The walkaway button is the user to not choose any of the dealer's options. If ran, and add, it the walkaway button will display "Player has walked away from the deal!" in the console. 